### PR TITLE
🧹 Refactor complex adapter selection logic

### DIFF
--- a/src/SpreadCompat.php
+++ b/src/SpreadCompat.php
@@ -36,46 +36,61 @@ class SpreadCompat
         }
 
         $ext = strtolower($ext);
+        $adapter = match ($ext) {
+            self::EXT_XLS => self::getXlsAdapter(),
+            self::EXT_CSV => self::getCsvAdapter(),
+            self::EXT_XLSX => self::getXlsxAdapter(),
+            default => null,
+        };
 
-        // Legacy xls is only supported by PhpSpreadsheet
-        if ($ext === self::EXT_XLS) {
-            if (class_exists(\PhpOffice\PhpSpreadsheet\Worksheet\Row::class)) {
-                return self::PHP_SPREADSHEET;
-            }
+        if ($adapter === null) {
+            throw new Exception("No adapter found for $ext");
         }
 
-        if ($ext === self::EXT_CSV) {
-            if (self::$preferredCsvAdapter !== null) {
-                return self::$preferredCsvAdapter;
-            }
-            if (class_exists(\League\Csv\Reader::class)) {
-                return self::LEAGUE;
-            }
-            if (class_exists(\OpenSpout\Common\Entity\Row::class)) {
-                return self::OPEN_SPOUT;
-            }
-            return self::NATIVE;
+        return $adapter;
+    }
 
-            // You probably don't want to use php spreadsheet for csv
+    /**
+     * Legacy xls is only supported by PhpSpreadsheet
+     */
+    private static function getXlsAdapter(): ?string
+    {
+        if (class_exists(\PhpOffice\PhpSpreadsheet\Worksheet\Row::class)) {
+            return self::PHP_SPREADSHEET;
         }
+        return null;
+    }
 
-        if ($ext === self::EXT_XLSX) {
-            if (self::$preferredXslxAdapter !== null) {
-                return self::$preferredXslxAdapter;
-            }
-            if (class_exists(\Shuchkin\SimpleXLSX::class)) {
-                return self::SIMPLE;
-            }
-            if (class_exists(\OpenSpout\Common\Entity\Row::class)) {
-                return self::OPEN_SPOUT;
-            }
-            if (class_exists(\PhpOffice\PhpSpreadsheet\Worksheet\Row::class)) {
-                return self::PHP_SPREADSHEET;
-            }
-            return self::NATIVE;
+    private static function getCsvAdapter(): string
+    {
+        if (self::$preferredCsvAdapter !== null) {
+            return self::$preferredCsvAdapter;
         }
+        if (class_exists(\League\Csv\Reader::class)) {
+            return self::LEAGUE;
+        }
+        if (class_exists(\OpenSpout\Common\Entity\Row::class)) {
+            return self::OPEN_SPOUT;
+        }
+        // You probably don't want to use php spreadsheet for csv
+        return self::NATIVE;
+    }
 
-        throw new Exception("No adapter found for $ext");
+    private static function getXlsxAdapter(): string
+    {
+        if (self::$preferredXslxAdapter !== null) {
+            return self::$preferredXslxAdapter;
+        }
+        if (class_exists(\Shuchkin\SimpleXLSX::class)) {
+            return self::SIMPLE;
+        }
+        if (class_exists(\OpenSpout\Common\Entity\Row::class)) {
+            return self::OPEN_SPOUT;
+        }
+        if (class_exists(\PhpOffice\PhpSpreadsheet\Worksheet\Row::class)) {
+            return self::PHP_SPREADSHEET;
+        }
+        return self::NATIVE;
     }
 
     public static function getAdapter(string $ext): SpreadInterface


### PR DESCRIPTION
The `getAdapterName` method in `src/SpreadCompat.php` was refactored to use a more modern and readable approach. By using a `match` expression and extracting the logic for each file extension into private static methods, the code is now easier to maintain and extend. The original functionality, including library detection and preferred adapter overrides, remains unchanged. Verification was performed using a custom script and syntax checks.

---
*PR created automatically by Jules for task [7468706218506166216](https://jules.google.com/task/7468706218506166216) started by @lekoala*