### PR TITLE
🧹 fix potential resource leak in CsvAdapter::detectSeparator

### DIFF
--- a/src/Csv/CsvAdapter.php
+++ b/src/Csv/CsvAdapter.php
@@ -75,13 +75,16 @@ abstract class CsvAdapter implements SpreadInterface
         $line = "";
         if (is_string($streamOrFile)) {
             if (is_file($streamOrFile)) {
-                $streamOrFile = fopen($streamOrFile, 'r');
+                $h = fopen($streamOrFile, 'r');
+                if ($h) {
+                    $line = fgets($h);
+                    fclose($h);
+                }
             } else {
                 $line = preg_split('/\r\n|\r|\n/', $streamOrFile, 1);
                 $line = $line[0] ?? "";
             }
-        }
-        if (is_resource($streamOrFile)) {
+        } elseif (is_resource($streamOrFile)) {
             $line = fgets($streamOrFile);
             rewind($streamOrFile);
         }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is a potential resource leak in `CsvAdapter::detectSeparator` where a file was opened with `fopen` but never closed with `fclose`.

💡 **Why:** Explicitly closing file handles is a best practice that improves maintainability and prevents resource exhaustion, especially in environments where automatic garbage collection might be delayed or where many files are processed.

✅ **Verification:** 
- Created a reproduction script to verify the logic.
- Created a functional test script to ensure `detectSeparator` still correctly identifies separators for strings, files, and resources, and correctly handles rewinding for external resources.
- Verified that the changes do not introduce regressions in the core logic.
- Cleaned up all temporary test files before submission.

✨ **Result:** Improved resource management in `CsvAdapter::detectSeparator`.

---
*PR created automatically by Jules for task [12864080889078268423](https://jules.google.com/task/12864080889078268423) started by @lekoala*