### PR TITLE
🔒 Fix Insecure Temporary File Creation in Native Xlsx Adapter

### DIFF
--- a/src/Xlsx/Native.php
+++ b/src/Xlsx/Native.php
@@ -611,11 +611,13 @@ XML;
 
             // close() will try to rename the file, but we cannot rename to/from temp dir
             $mode = ZipArchive::CREATE | ZipArchive::OVERWRITE;
-            // Simply use root folder
-            $baseName = '_xlsx_native.tmp';
-            // Or use specified temp path (should not be the sys temp dir)
             if ($this->tempPath) {
-                $baseName = $this->tempPath . DIRECTORY_SEPARATOR . $baseName;
+                $baseName = tempnam($this->tempPath, 'xlsx_native');
+                if (!$baseName) {
+                    throw new Exception("Failed to create temp file in " . $this->tempPath);
+                }
+            } else {
+                $baseName = SpreadCompat::getTempFilename();
             }
 
             $zip = new ZipArchive();
@@ -663,11 +665,8 @@ XML;
             SpreadCompat::outputHeaders($mime, $filename);
 
             $tempFilename = SpreadCompat::getTempFilename();
-            if (is_file($tempFilename)) {
-                unlink($tempFilename); // ZipArchive needs no file
-            }
             $zip = new ZipArchive();
-            $zip->open($tempFilename, ZipArchive::CREATE);
+            $zip->open($tempFilename, ZipArchive::CREATE | ZipArchive::OVERWRITE);
             $this->write($zip, $data);
             $zip->close();
             readfile($tempFilename);


### PR DESCRIPTION
The Native Xlsx Adapter in `src/Xlsx/Native.php` was using a predictable temporary filename `_xlsx_native.tmp` in the current working directory. This allowed for potential race conditions and file overwriting by concurrent processes or malicious actors.

Furthermore, the `output` method had a pattern of unlinking a temporary file before opening it with `ZipArchive::CREATE`, which introduced a small window for an attacker to create a symbolic link at that location.

This PR fixes these issues by:
1. Using `tempnam()` to generate unique temporary filenames.
2. Utilizing `ZipArchive::OVERWRITE` to safely open existing files created by `tempnam`.
3. Removing the unsafe `unlink` before `open` pattern.

These changes follow security best practices for temporary file creation in PHP.

---
*PR created automatically by Jules for task [8978364217943565652](https://jules.google.com/task/8978364217943565652) started by @lekoala*