### PR TITLE
⚡ Optimize League CSV reading by using yield from

### DIFF
--- a/src/Csv/League.php
+++ b/src/Csv/League.php
@@ -114,9 +114,7 @@ class League extends CsvAdapter
             $csv->setHeaderOffset(0);
         }
 
-        foreach ($csv as $record) {
-            yield $record;
-        }
+        yield from $csv;
     }
 
     /**


### PR DESCRIPTION
### ⚡ Performance Optimization

#### 💡 What:
Replaced a redundant `foreach` loop that yielded records from a `League\Csv\Reader` object with the `yield from` statement in `src/Csv/League.php`.

#### 🎯 Why:
The `yield from` syntax in PHP delegates the iteration to the underlying `Traversable` object at the engine level. This is more efficient than a manual `foreach` loop because it avoids the overhead of multiple generator resumes and suspensions for each yielded element.

#### 📊 Measured Improvement:
- **Baseline:** According to `docs/bench-read.md`, the baseline average time for `LeKoala\SpreadCompat\Csv\League` is **0.0093s** for a 170K CSV file.
- **Rationale:** Although I was unable to run a comparative benchmark in the provided environment due to missing dependencies, `yield from` is a standard PHP optimization for this pattern and results in cleaner, faster code.

#### ✅ Verification:
- Checked for syntax errors using `php -l`.
- Verified logic via code review.
- Confirmed that `League\Csv\Reader` implements `Iterator`, making it compatible with `yield from`.

---
*PR created automatically by Jules for task [8060476814761697987](https://jules.google.com/task/8060476814761697987) started by @lekoala*