### PR TITLE
🔒 [security] Fix XXE vulnerability in Native XLSX adapter

### DIFF
--- a/src/Xlsx/Native.php
+++ b/src/Xlsx/Native.php
@@ -47,7 +47,7 @@ class Native extends XlsxAdapter
         $ssXml = null;
         $ssData = ZipUtils::getData($zip, 'xl/sharedStrings.xml');
         if ($ssData) {
-            $ssXml = new SimpleXMLElement($ssData);
+            $ssXml = new SimpleXMLElement($ssData, LIBXML_NONET);
         }
 
         // styles
@@ -56,7 +56,7 @@ class Native extends XlsxAdapter
         $cellFormats = [];
         $stylesData = ZipUtils::getData($zip, 'xl/styles.xml');
         if ($stylesData) {
-            $stylesXml = new SimpleXMLElement($stylesData);
+            $stylesXml = new SimpleXMLElement($stylesData, LIBXML_NONET);
 
             // Number formats. Built-in formats are optional and may not be included
             if (isset($stylesXml->numFmts)) {
@@ -113,7 +113,7 @@ class Native extends XlsxAdapter
         };
 
         // Process data
-        $wsXml = new SimpleXMLElement($wsData);
+        $wsXml = new SimpleXMLElement($wsData, LIBXML_NONET);
         $headers = null;
         $rowCount = 0;
         $startRow = $this->assoc ? 1 : 0;


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
The `Native` XLSX adapter was using `SimpleXMLElement` to parse internal XML components of Excel files without disabling network access for external entity resolution.

### ⚠️ Risk: The potential impact if left unfixed
An attacker could provide a malicious XLSX file containing XML External Entities (XXE). This could lead to Server-Side Request Forgery (SSRF) or data exfiltration from the server environment if the XML parser attempted to resolve these external entities over the network.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix adds the `LIBXML_NONET` flag to the `SimpleXMLElement` constructor in all three locations where it's used in `src/Xlsx/Native.php`. This explicitly disables network access during XML parsing, which is a recommended security hardening practice and doesn't affect standard XLSX parsing as these files are self-contained.

---
*PR created automatically by Jules for task [8060623813413781411](https://jules.google.com/task/8060623813413781411) started by @lekoala*