### PR TITLE
Remove encoding TODOs from OpenSpout XLSX writer

### DIFF
--- a/src/Xlsx/OpenSpout.php
+++ b/src/Xlsx/OpenSpout.php
@@ -148,8 +148,6 @@ class OpenSpout extends XlsxAdapter
         $this->configure(...$opts);
         $writer = $this->getWriter();
 
-        //TODO: encoding?
-
         $writer->openToFile($filename);
         $this->setSheetView($writer);
         foreach ($data as $row) {
@@ -169,8 +167,6 @@ class OpenSpout extends XlsxAdapter
     {
         $this->configure(...$opts);
         $writer = $this->getWriter();
-
-        //TODO: encoding?
 
         $writer->openToBrowser($filename);
         $this->setSheetView($writer);


### PR DESCRIPTION
Removed non-actionable `//TODO: encoding?` comments from `writeFile` and `output` methods in `src/Xlsx/OpenSpout.php`. Since XLSX is standard-bound to UTF-8 and OpenSpout manages this internally, explicit encoding configuration is neither supported nor required for this adapter.

---
*PR created automatically by Jules for task [14820203072069835201](https://jules.google.com/task/14820203072069835201) started by @lekoala*