### PR TITLE
🔒 Fix predictable temp file prefix (CWE-377)

### DIFF
--- a/src/SpreadCompat.php
+++ b/src/SpreadCompat.php
@@ -179,11 +179,21 @@ class SpreadCompat
      */
     public static function getTempFilename(): string
     {
-        $result = tempnam(sys_get_temp_dir(), 'S_C'); // windows only use the 3 first letters
-        if ($result === false) {
-            throw new Exception("Unable to create temp file");
+        $tmpDir = sys_get_temp_dir();
+        $attempts = 0;
+        $maxAttempts = 10;
+        while ($attempts < $maxAttempts) {
+            $random = bin2hex(random_bytes(16));
+            $filename = $tmpDir . DIRECTORY_SEPARATOR . 'S_C' . $random . '.tmp';
+            $handle = @fopen($filename, 'x');
+            if ($handle !== false) {
+                fclose($handle);
+                chmod($filename, 0600);
+                return $filename;
+            }
+            $attempts++;
         }
-        return $result;
+        throw new Exception("Unable to create a unique temporary file after $maxAttempts attempts");
     }
 
     public static function stringToTempFile(string $data): string


### PR DESCRIPTION
Fixed a security vulnerability in `SpreadCompat::getTempFilename()` where `tempnam()` was used with a predictable prefix, leading to potential CWE-377 (Insecure Temporary File) issues. The new implementation uses cryptographically secure random bytes for filenames, ensures atomic creation using the 'x' flag with `fopen()`, and sets restrictive 0600 permissions. The `isTempFile()` method was restored to maintain backward compatibility.

---
*PR created automatically by Jules for task [8890256360598028663](https://jules.google.com/task/8890256360598028663) started by @lekoala*