### PR TITLE
🧪 [testing] improve ensureExtension reliability and coverage

### DIFF
--- a/src/SpreadCompat.php
+++ b/src/SpreadCompat.php
@@ -288,7 +288,7 @@ class SpreadCompat
     public static function ensureExtension(string $filename, string $ext): string
     {
         $fileExt = pathinfo($filename, PATHINFO_EXTENSION);
-        if ($fileExt != $ext) {
+        if (strtolower($fileExt) != strtolower($ext)) {
             $filename .= ".$ext";
         }
         return $filename;

--- a/tests/SpreadCompatCommonTest.php
+++ b/tests/SpreadCompatCommonTest.php
@@ -141,4 +141,20 @@ class SpreadCompatCommonTest extends TestCase
         fclose($stream);
         fclose($emptyStream);
     }
+
+    public function testEnsureExtension()
+    {
+        // Already has extension
+        self::assertEquals('test.csv', SpreadCompat::ensureExtension('test.csv', 'csv'));
+        // Missing extension
+        self::assertEquals('test.csv', SpreadCompat::ensureExtension('test', 'csv'));
+        // Different extension
+        self::assertEquals('test.xlsx.csv', SpreadCompat::ensureExtension('test.xlsx', 'csv'));
+        // Case sensitivity (currently fails, but should pass after fix)
+        self::assertEquals('test.CSV', SpreadCompat::ensureExtension('test.CSV', 'csv'));
+        // Path with extension
+        self::assertEquals('/path/to/test.csv', SpreadCompat::ensureExtension('/path/to/test.csv', 'csv'));
+        // Path without extension
+        self::assertEquals('/path/to/test.csv', SpreadCompat::ensureExtension('/path/to/test', 'csv'));
+    }
 }


### PR DESCRIPTION
This PR addresses a testing gap for the `ensureExtension` method in `SpreadCompat.php`.

### 🎯 What
- Added comprehensive unit tests for `LeKoala\SpreadCompat\SpreadCompat::ensureExtension`.
- Fixed a bug where the method would redundantly append an extension if the casing didn't match (e.g., `file.CSV` + `csv` would result in `file.CSV.csv`).

### 📊 Coverage
The new tests cover:
- Filename already having the correct extension (both same and different casing).
- Filename missing the extension.
- Filename having a different extension.
- Filename with full paths.

### ✨ Result
Improved reliability of the `ensureExtension` utility method and guaranteed consistent behavior regardless of extension casing.

---
*PR created automatically by Jules for task [9966396689069383528](https://jules.google.com/task/9966396689069383528) started by @lekoala*