### PR TITLE
🧹 Remove unused SpreadCompat import in OpenSpout.php

### DIFF
--- a/src/Xlsx/OpenSpout.php
+++ b/src/Xlsx/OpenSpout.php
@@ -9,7 +9,6 @@ use OpenSpout\Common\Entity\Row;
 use OpenSpout\Writer\AutoFilter;
 use OpenSpout\Reader\XLSX\Reader;
 use OpenSpout\Writer\XLSX\Writer;
-use LeKoala\SpreadCompat\SpreadCompat;
 use OpenSpout\Writer\XLSX\Entity\SheetView;
 use OpenSpout\Writer\XLSX\Properties;
 


### PR DESCRIPTION
This PR removes an unused `use LeKoala\SpreadCompat\SpreadCompat;` statement from `src/Xlsx/OpenSpout.php`. 

🎯 **What:** Removed the unused import `LeKoala\SpreadCompat\SpreadCompat`.
💡 **Why:** Unused imports clutter the codebase and can slightly affect parsing performance. Removing them improves maintainability and readability.
✅ **Verification:** 
- Ran `php -l src/Xlsx/OpenSpout.php` to ensure no syntax errors.
- Created and executed a standalone verification script that mocked the necessary `OpenSpout` dependencies to confirm the class still loads and instantiates correctly.
✨ **Result:** Cleaner code in `src/Xlsx/OpenSpout.php` with no change in functionality.

---
*PR created automatically by Jules for task [7393522795539100361](https://jules.google.com/task/7393522795539100361) started by @lekoala*