### PR TITLE
🔒 Document CSV Formula Injection protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ $options->adapter = SpreadCompat::NATIVE;
 $csvData = SpreadCompat::readString($csv, $options);
 ```
 
+## Security
+
+### CSV Formula Injection
+
+When exporting to CSV, cell values starting with `=`, `+`, `-`, `@`, `\t`, or `\r` can be interpreted as formulas by spreadsheet software like Excel. This is known as [CSV Formula Injection](https://owasp.org/www-community/attacks/CSV_Injection).
+
+By default, this library does NOT escape these characters to ensure that the data is not altered and remains compatible with other tools that may expect raw data.
+
+If you are generating CSV files for end users to open in Excel and want to protect them from potential formula injection, you should enable the `escapeFormulas` option:
+
+```php
+SpreadCompat::write('myfile.csv', $data, escapeFormulas: true);
+```
+
+This will prepend a single quote (`'`) to any cell value that could be interpreted as a formula.
+
 ## Worksheets
 
 This package supports only 1 worksheet, as it is meant to be able to replace csv by xlsx or vice versa


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
CSV Formula Injection (CWE-1236) where cell values starting with symbols like `=`, `+`, `-`, `@`, `\t`, or `\r` can be interpreted as formulas by spreadsheet software.

### ⚠️ Risk: The potential impact if left unfixed
Malicious actors could inject formulas into CSV exports that could execute arbitrary commands or exfiltrate data when opened in tools like Microsoft Excel.

### 🛡️ Solution: How the fix addresses the vulnerability
This update adds a "Security" section to the `README.md` to inform developers about the risk and how to mitigate it by enabling the `escapeFormulas` option in their `SpreadCompat::write` calls. This approach addresses the security concern while respecting the requirement to keep the default behavior unaltered for maximum compatibility with raw data processing tools.

---
*PR created automatically by Jules for task [4611817492705203097](https://jules.google.com/task/4611817492705203097) started by @lekoala*