### PR TITLE
⚡ Fix temporary file leaks in readString and writeString

### DIFF
--- a/src/Common/ReadWriteString.php
+++ b/src/Common/ReadWriteString.php
@@ -33,8 +33,11 @@ trait ReadWriteString
     ): Generator {
         $filename = SpreadCompat::getTempFilename();
         file_put_contents($filename, $contents);
-        yield from $this->readFile($filename, ...$opts);
-        unlink($filename);
+        try {
+            yield from $this->readFile($filename, ...$opts);
+        } finally {
+            unlink($filename);
+        }
     }
 
     public function writeString(
@@ -42,12 +45,15 @@ trait ReadWriteString
         ...$opts
     ): string {
         $filename = SpreadCompat::getTempFilename();
-        $this->writeFile($data, $filename, ...$opts);
-        $contents = file_get_contents($filename);
-        if (!$contents) {
-            $contents = "";
+        try {
+            $this->writeFile($data, $filename, ...$opts);
+            $contents = file_get_contents($filename);
+            if (!$contents) {
+                $contents = "";
+            }
+        } finally {
+            unlink($filename);
         }
-        unlink($filename);
         return $contents;
     }
 }

--- a/src/Csv/OpenSpout.php
+++ b/src/Csv/OpenSpout.php
@@ -24,8 +24,11 @@ class OpenSpout extends CsvAdapter
     ): Generator {
         $filename = SpreadCompat::getTempFilename();
         file_put_contents($filename, $contents);
-        yield from $this->readFile($filename);
-        unlink($filename);
+        try {
+            yield from $this->readFile($filename, ...$opts);
+        } finally {
+            unlink($filename);
+        }
     }
 
     /**
@@ -196,12 +199,15 @@ class OpenSpout extends CsvAdapter
     {
         $this->configure(...$opts);
         $filename = SpreadCompat::getTempFilename();
-        $this->writeFile($data, $filename);
-        $contents = file_get_contents($filename);
-        if (!$contents) {
-            $contents = "";
+        try {
+            $this->writeFile($data, $filename);
+            $contents = file_get_contents($filename);
+            if (!$contents) {
+                $contents = "";
+            }
+        } finally {
+            unlink($filename);
         }
-        unlink($filename);
         return $contents;
     }
 

--- a/src/Csv/PhpSpreadsheet.php
+++ b/src/Csv/PhpSpreadsheet.php
@@ -137,12 +137,15 @@ class PhpSpreadsheet extends CsvAdapter
     {
         $this->configure(...$opts);
         $filename = SpreadCompat::getTempFilename();
-        $this->writeFile($data, $filename);
-        $contents = file_get_contents($filename);
-        if (!$contents) {
-            $contents = "";
+        try {
+            $this->writeFile($data, $filename);
+            $contents = file_get_contents($filename);
+            if (!$contents) {
+                $contents = "";
+            }
+        } finally {
+            unlink($filename);
         }
-        unlink($filename);
         return $contents;
     }
 


### PR DESCRIPTION
This PR addresses a temporary file leak in the `readString` and `writeString` methods by ensuring that temporary files are always deleted using `try...finally` blocks.

🎯 **What:**
- Added `try...finally` around `yield from` in `readString` to ensure `unlink()` is called even if the generator is closed prematurely (e.g., during iteration).
- Added `try...finally` in `writeString` to guarantee temporary file cleanup if an exception occurs during file processing.
- Fixed a missing `...$opts` argument in `OpenSpout::readString` when calling `readFile`.

⚠️ **Risk:**
Low. This uses standard PHP generator and exception handling patterns.

🛡️ **Solution:**
- Modified `src/Csv/OpenSpout.php`, `src/Csv/PhpSpreadsheet.php`, and the `src/Common/ReadWriteString.php` trait to use `try...finally` for file cleanup.

📊 **Measured Improvement:**
Verified with a reproduction script that `OpenSpout::readString` no longer leaves `S_C*.tmp` files in the temporary directory when iteration is stopped early. Previously, each early-exited iteration leaked one file.

---
*PR created automatically by Jules for task [11412351500145288938](https://jules.google.com/task/11412351500145288938) started by @lekoala*