### PR TITLE
🧪 [test] add exception test for OpenSpout readStream

### DIFF
--- a/tests/SpreadCompatCsvTest.php
+++ b/tests/SpreadCompatCsvTest.php
@@ -340,4 +340,13 @@ CSV;
         $data = iterator_to_array($generator);
         self::assertCount(1, $data, "Should be one line");
     }
+
+    public function testOpenSpoutCannotReadStream()
+    {
+        $openSpout = new OpenSpout();
+        $stream = fopen('php://memory', 'r');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("OpenSpout doesn't support streams");
+        iterator_to_array($openSpout->readStream($stream));
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: missing exception test for `OpenSpout::readStream`.
📊 **Coverage:** Added `testOpenSpoutCannotReadStream` scenario to `tests/SpreadCompatCsvTest.php`.
✨ **Result:** Improved test coverage and reliability by explicitly testing the unsupported stream reading functionality in OpenSpout.

---
*PR created automatically by Jules for task [12717143129650167338](https://jules.google.com/task/12717143129650167338) started by @lekoala*