### PR TITLE
🧪 [testing improvement] Add test for isTempFile utility

### DIFF
--- a/tests/SpreadCompatCommonTest.php
+++ b/tests/SpreadCompatCommonTest.php
@@ -201,4 +201,17 @@ class SpreadCompatCommonTest extends TestCase
         // Opening a non-existent file for reading should fail
         SpreadCompat::getInputStream('/non/existent/file');
     }
+
+    public function testIsTempFile()
+    {
+        self::assertTrue(SpreadCompat::isTempFile('/tmp/S_Cabcdef.tmp'));
+        self::assertTrue(SpreadCompat::isTempFile('S_Cabcdef.tmp'));
+        self::assertFalse(SpreadCompat::isTempFile('/tmp/not_a_temp_file.tmp'));
+        self::assertFalse(SpreadCompat::isTempFile('not_a_temp_file.tmp'));
+        self::assertFalse(SpreadCompat::isTempFile('/S_C_dir/file.txt'));
+
+        $temp = SpreadCompat::getTempFilename();
+        self::assertTrue(SpreadCompat::isTempFile($temp));
+        unlink($temp);
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the missing test for the `isTempFile` utility in `SpreadCompat.php`.

📊 **Coverage:** The new `testIsTempFile` in `SpreadCompatCommonTest.php` covers:
- Positive matches for files with the `S_C` prefix (both absolute paths and filenames).
- Negative matches for files without the prefix.
- Edge cases where the prefix exists in the directory path but not the filename.
- Integration with `getTempFilename()` to ensure consistency.

✨ **Result:** Improved test coverage and reliability for the temporary file identification logic.

---
*PR created automatically by Jules for task [837506625088099894](https://jules.google.com/task/837506625088099894) started by @lekoala*