### PR TITLE
Support encoding in OpenSpout CSV output

### DIFF
--- a/src/Csv/OpenSpout.php
+++ b/src/Csv/OpenSpout.php
@@ -222,14 +222,12 @@ class OpenSpout extends CsvAdapter
         $this->configure(...$opts);
         $writer = $this->getWriter();
 
-        //TODO: encoding?
-
         $writer->openToFile($filename);
         if (!empty($this->headers)) {
-            $writer->addRow(Row::fromValues(array_values($this->escapeRow($this->headers))));
+            $writer->addRow(Row::fromValues(array_values($this->encodeRow($this->escapeRow($this->headers)))));
         }
         foreach ($data as $row) {
-            $writer->addRow(Row::fromValues(array_values($this->escapeRow($row))));
+            $writer->addRow(Row::fromValues(array_values($this->encodeRow($this->escapeRow($row)))));
         }
         $writer->close();
         return true;
@@ -246,15 +244,44 @@ class OpenSpout extends CsvAdapter
         $this->configure(...$opts);
         $writer = $this->getWriter();
 
-        //TODO: encoding?
+        $outputEncoding = $this->getOutputEncoding();
+        if ($outputEncoding && $outputEncoding !== 'UTF-8') {
+            SpreadCompat::outputHeaders('text/csv; charset=' . $outputEncoding, $filename);
+            $writer->openToFile('php://output');
+        } else {
+            $writer->openToBrowser($filename);
+        }
 
-        $writer->openToBrowser($filename);
         if (!empty($this->headers)) {
-            $writer->addRow(Row::fromValues(array_values($this->escapeRow($this->headers))));
+            $writer->addRow(Row::fromValues(array_values($this->encodeRow($this->escapeRow($this->headers)))));
         }
         foreach ($data as $row) {
-            $writer->addRow(Row::fromValues(array_values($this->escapeRow($row))));
+            $writer->addRow(Row::fromValues(array_values($this->encodeRow($this->escapeRow($row)))));
         }
         $writer->close();
+    }
+
+    /**
+     * @template T of array<mixed>
+     * @param T $row
+     * @return T
+     */
+    protected function encodeRow(array $row): array
+    {
+        $outputEncoding = $this->getOutputEncoding();
+        if (!$outputEncoding) {
+            return $row;
+        }
+        $inputEncoding = mb_internal_encoding();
+        if ($inputEncoding === $outputEncoding) {
+            return $row;
+        }
+        foreach ($row as &$cell) {
+            if (is_string($cell)) {
+                $cell = mb_convert_encoding($cell, $outputEncoding, $inputEncoding);
+            }
+        }
+        /** @var T $row */
+        return $row;
     }
 }


### PR DESCRIPTION
This PR adds support for configured output encoding in the OpenSpout CSV adapter.

### 🎯 What
The OpenSpout CSV writer now respects the `outputEncoding` configuration. Previously, it defaulted to UTF-8 without conversion.

### ⚠️ Risk
Low. The default behavior remains unchanged (UTF-8). Non-UTF-8 encodings are now properly converted, and corresponding HTTP headers are sent when outputting to the browser.

### 🛡️ Solution
- Added a protected `encodeRow` method using `mb_convert_encoding`.
- Integrated `encodeRow` into `writeFile` and `output`.
- Updated `output` to use `SpreadCompat::outputHeaders` and `php://output` when a non-UTF-8 encoding is specified, bypassing OpenSpout's default browser output to ensure correct charset headers.

---
*PR created automatically by Jules for task [10962995867541988934](https://jules.google.com/task/10962995867541988934) started by @lekoala*