### PR TITLE
🧪 [testing-improvement] Add unit tests for SpreadCompat::excelCell and getLetter

### DIFF
--- a/tests/SpreadCompatCommonTest.php
+++ b/tests/SpreadCompatCommonTest.php
@@ -214,4 +214,24 @@ class SpreadCompatCommonTest extends TestCase
         self::assertTrue(SpreadCompat::isTempFile($temp));
         unlink($temp);
     }
+
+    public function testGetLetter()
+    {
+        self::assertEquals('A', SpreadCompat::getLetter(1));
+        self::assertEquals('Z', SpreadCompat::getLetter(26));
+        self::assertEquals('AA', SpreadCompat::getLetter(27));
+        self::assertEquals('ZZ', SpreadCompat::getLetter(702));
+        self::assertEquals('AAA', SpreadCompat::getLetter(703));
+        self::assertEquals('XFD', SpreadCompat::getLetter(16384));
+    }
+
+    public function testExcelCell()
+    {
+        self::assertEquals('A1', SpreadCompat::excelCell(0, 0));
+        self::assertEquals('$A$1', SpreadCompat::excelCell(0, 0, true));
+        self::assertEquals('Z10', SpreadCompat::excelCell(9, 25));
+        self::assertEquals('$Z$10', SpreadCompat::excelCell(9, 25, true));
+        self::assertEquals('AA100', SpreadCompat::excelCell(99, 26));
+        self::assertEquals('XFD16384', SpreadCompat::excelCell(16383, 16383));
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the `SpreadCompat::excelCell` and `SpreadCompat::getLetter` utility methods.
📊 **Coverage:**
- `SpreadCompat::getLetter`: Tested with 1, 26, 27, 702, 703, and 16384 to ensure correct letter mapping across single, double, and triple-letter columns.
- `SpreadCompat::excelCell`: Tested with various row/column combinations and the `absolute` flag to ensure correct A1-style reference generation.
✨ **Result:** Improved test coverage for core utility functions in the `SpreadCompat` class, providing a safety net for future refactoring of coordinate logic.

---
*PR created automatically by Jules for task [8823110893630881527](https://jules.google.com/task/8823110893630881527) started by @lekoala*