### PR TITLE
🧹 [remove unused RuntimeException import in League.php]

### DIFF
--- a/src/Csv/League.php
+++ b/src/Csv/League.php
@@ -9,7 +9,6 @@ use League\Csv\InvalidArgument;
 use League\Csv\Reader;
 use League\Csv\Writer;
 use League\Csv\CharsetConverter;
-use RuntimeException;
 use SplTempFileObject;
 
 class League extends CsvAdapter


### PR DESCRIPTION
🎯 **What:** Removed the unused `use RuntimeException;` statement from `src/Csv/League.php`.
💡 **Why:** Improving code maintainability by removing dead code/unused imports.
✅ **Verification:** Performed a recursive `grep` to ensure `RuntimeException` was not used anywhere in the file (including comments) and verified the file's syntax with `php -l`.
✨ **Result:** A cleaner and more readable `League.php` file.

---
*PR created automatically by Jules for task [6920235991745677944](https://jules.google.com/task/6920235991745677944) started by @lekoala*